### PR TITLE
Optimizer Selector へのパッチ

### DIFF
--- a/blueoil/blueoil_init.py
+++ b/blueoil/blueoil_init.py
@@ -297,7 +297,6 @@ def ask_questions():
         'name': 'value',
         'message': 'select optimizer:',
         'choices': ['MomentumOptimizer',
-                    'GradientDescentOptimizer',
                     'AdamOptimizer'],
         'default': 'MomentumOptimizer'
     }

--- a/blueoil/generate_lmnet_config.py
+++ b/blueoil/generate_lmnet_config.py
@@ -147,9 +147,7 @@ def _blueoil_to_lmnet(blueoil_config):
     # trainer
     batch_size = blueoil_config["trainer"]["batch_size"]
     optimizer  = blueoil_config["trainer"]["optimizer"]
-    if optimizer == 'GradientDescentOptimizer':
-        optimizer_class = "tf.train.GradientDescentOptimizer"
-    elif optimizer == 'AdamOptimizer':
+    if optimizer == 'AdamOptimizer':
         optimizer_class = "tf.train.AdamOptimizer"
     elif optimizer == 'MomentumOptimizer':
         optimizer_class = "tf.train.MomentumOptimizer"

--- a/blueoil/templates/blueoil-config.tpl.yml
+++ b/blueoil/templates/blueoil-config.tpl.yml
@@ -14,8 +14,6 @@ trainer:
   # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
-  # SGD
-  #    https://www.tensorflow.org/api_docs/python/tf/train/GradientDescentOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
   optimizer: {{ training_optimizer }}

--- a/blueoil_test.sh
+++ b/blueoil_test.sh
@@ -15,6 +15,9 @@ fi
 TEST_LOG_NO=0
 FAILED_TEST_NO=""
 
+# list of avairable optimizers listed in blueoil_init.py
+OPTIMIZSERS=("MomentumOptimizer" "AdamOptimizer")
+
 function usage_exit(){
 	echo ""
 	echo "Usage"
@@ -89,8 +92,9 @@ function init_test(){
     NETWORK_NUMBER=$4
     DATASET_FORMAT_NUMBER=$5
     ENABLE_DATA_AUGMENTATION=$6
-    TRAINING_DATASET_PATH=$7
-    VALIDATION_DATASET_PATH=$8
+    OPTIMIZER_NUMBER=$7
+    TRAINING_DATASET_PATH=$8
+    VALIDATION_DATASET_PATH=$9
     CONFIG_NAME=${TEST_CONFIG_PREFIX}_${TEST_CASE}
     TEST_YML_CONFIG_FILE=./tests/config/${TEST_CASE}.yml
     echo "## Test of ${TEST_CASE}"
@@ -141,7 +145,7 @@ function init_test(){
         expect \"how many epochs do you run training (integer):\"
         send \"\b\b\b1\n\"
         expect \"select optimizer:\"
-        send \"\n\"
+        send \"${OPTIMIZER_NUMBER}\n\"
         expect \"initial learning rate:\"
         send \"\n\"
         expect \"choose learning rate setting(tune1 / tune2 / tune3 / fixed):\"
@@ -235,7 +239,8 @@ if [ "${YML_CONFIG_FILE}" == "" ]; then
             do
                 TRAINING_DATASET_PATH=$(get_yaml_param train_path tests/config/${TEST_CASE}.yml)
                 VALIDATION_DATASET_PATH=$(get_yaml_param test_path tests/config/${TEST_CASE}.yml)
-                init_test ${TEST_CASE} ${TASK_TYPE_NUMBER} 1 1 ${DATASET_FORMAT_NUMBER} ${ENABLE_DATA_AUGMENTATION} ${TRAINING_DATASET_PATH} ${VALIDATION_DATASET_PATH}
+                OPTIMIZER_NUMBER=$(($((${TASK_TYPE_NUMBER} % ${#OPTIMIZSERS[@]}))+1))
+                init_test ${TEST_CASE} ${TASK_TYPE_NUMBER} 1 1 ${DATASET_FORMAT_NUMBER} ${ENABLE_DATA_AUGMENTATION} ${OPTIMIZER_NUMBER} ${TRAINING_DATASET_PATH} ${VALIDATION_DATASET_PATH}
                 basic_test
                 if [ ${ADDITIONAL_TEST_FLAG} -eq 0 ]; then
                     # Run additional test only once

--- a/docs/usage/init.md
+++ b/docs/usage/init.md
@@ -51,3 +51,21 @@ common:
 ```
 
 Please see <a href="../reference/data_augmentor.html">the data augmentor reference page</a>, when you want to know about augmentation methods. the all of augmentation methods and parameter are explained, methods name in generated yaml correspond to class name under `lmnet.data_augmentor` in the reference.
+
+
+#### optimizer
+
+You can choose optimizer from Adam or Momentum. Each optimizer uses TensorFlow implementation. Please see TensorFlow documentation, [AdamOptimizer](https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer) and [MomentumOptimizer](https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer).
+
+generated yaml:
+
+```
+  # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
+  # Momentum
+  #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
+  # Adam
+  #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
+  optimizer: AdamOptimizer
+```
+
+Blueoil use this optimizers with your input learning rate. Other values are TensorFlow default described in TensorFlow documentation.

--- a/tests/config/caltech101_classification.yml
+++ b/tests/config/caltech101_classification.yml
@@ -14,11 +14,9 @@ trainer:
   # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
-  # SGD
-  #    https://www.tensorflow.org/api_docs/python/tf/train/GradientDescentOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
-  optimizer: MomentumOptimizer
+  optimizer: AdamOptimizer
   # supported 'learning_rate_schedule' is 'constant', '2-step-decay', '3-step-decay', '3-step-decay-with-warmup' ({epochs} is the number of training epochs you entered before).
   #   'constant' -> constant learning rate.
   #   '2-step-decay' -> learning rate decrease by 1/10 on {epochs}/2 and {epochs}-1.

--- a/tests/config/caltech101_classification_has_validation.yml
+++ b/tests/config/caltech101_classification_has_validation.yml
@@ -14,11 +14,9 @@ trainer:
   # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
-  # SGD
-  #    https://www.tensorflow.org/api_docs/python/tf/train/GradientDescentOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
-  optimizer: MomentumOptimizer
+  optimizer: AdamOptimizer
   # supported 'learning_rate_schedule' is 'constant', '2-step-decay', '3-step-decay', '3-step-decay-with-warmup' ({epochs} is the number of training epochs you entered before).
   #   'constant' -> constant learning rate.
   #   '2-step-decay' -> learning rate decrease by 1/10 on {epochs}/2 and {epochs}-1.

--- a/tests/config/delta_mark_classification.yml
+++ b/tests/config/delta_mark_classification.yml
@@ -14,11 +14,9 @@ trainer:
   # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
-  # SGD
-  #    https://www.tensorflow.org/api_docs/python/tf/train/GradientDescentOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
-  optimizer: MomentumOptimizer
+  optimizer: AdamOptimizer
   # supported 'learning_rate_schedule' is 'constant', '2-step-decay', '3-step-decay', '3-step-decay-with-warmup' ({epochs} is the number of training epochs you entered before).
   #   'constant' -> constant learning rate.
   #   '2-step-decay' -> learning rate decrease by 1/10 on {epochs}/2 and {epochs}-1.

--- a/tests/config/delta_mark_classification_has_validation.yml
+++ b/tests/config/delta_mark_classification_has_validation.yml
@@ -14,11 +14,9 @@ trainer:
   # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
-  # SGD
-  #    https://www.tensorflow.org/api_docs/python/tf/train/GradientDescentOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
-  optimizer: MomentumOptimizer
+  optimizer: AdamOptimizer
   # supported 'learning_rate_schedule' is 'constant', '2-step-decay', '3-step-decay', '3-step-decay-with-warmup' ({epochs} is the number of training epochs you entered before).
   #   'constant' -> constant learning rate.
   #   '2-step-decay' -> learning rate decrease by 1/10 on {epochs}/2 and {epochs}-1.

--- a/tests/config/delta_mark_object_detection.yml
+++ b/tests/config/delta_mark_object_detection.yml
@@ -14,8 +14,6 @@ trainer:
   # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
-  # SGD
-  #    https://www.tensorflow.org/api_docs/python/tf/train/GradientDescentOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
   optimizer: MomentumOptimizer

--- a/tests/config/delta_mark_object_detection_has_validation.yml
+++ b/tests/config/delta_mark_object_detection_has_validation.yml
@@ -14,8 +14,6 @@ trainer:
   # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
-  # SGD
-  #    https://www.tensorflow.org/api_docs/python/tf/train/GradientDescentOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
   optimizer: MomentumOptimizer

--- a/tests/config/make_yml_config.py
+++ b/tests/config/make_yml_config.py
@@ -104,17 +104,15 @@ trainer_optimizer_comment = """\
   # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
-  # SGD
-  #    https://www.tensorflow.org/api_docs/python/tf/train/GradientDescentOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
 """
 
 trainer_optimizers = [
-    '  optimizer: MomentumOptimizer\n',
-    '  optimizer: MomentumOptimizer\n',
-    '  optimizer: MomentumOptimizer\n',
-    '  optimizer: MomentumOptimizer\n',
+    '  optimizer: AdamOptimizer\n',
+    '  optimizer: AdamOptimizer\n',
+    '  optimizer: AdamOptimizer\n',
+    '  optimizer: AdamOptimizer\n',
     '  optimizer: MomentumOptimizer\n',
     '  optimizer: MomentumOptimizer\n',
     '  optimizer: MomentumOptimizer\n',

--- a/tests/config/openimagesv4_object_detection.yml
+++ b/tests/config/openimagesv4_object_detection.yml
@@ -14,8 +14,6 @@ trainer:
   # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
-  # SGD
-  #    https://www.tensorflow.org/api_docs/python/tf/train/GradientDescentOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
   optimizer: MomentumOptimizer

--- a/tests/config/openimagesv4_object_detection_has_validation.yml
+++ b/tests/config/openimagesv4_object_detection_has_validation.yml
@@ -14,8 +14,6 @@ trainer:
   # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
-  # SGD
-  #    https://www.tensorflow.org/api_docs/python/tf/train/GradientDescentOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
   optimizer: MomentumOptimizer


### PR DESCRIPTION
Blueoil メインリポジトリへのマージに向け、いくつか変更を加えました！

- `blueoil_test.sh` でのテストを追加しました
  - Classification タスクで Adam 、Object Detection で Momentum を使ってテストを使うように変更しました
- ドキュメントの追加
  - `docs/usage/init.md` に Optimizer の説明を記載しました
- `GradientDescentOptimizer` の削除　
  - `GradientDescentOptimizer` は使わなそうで、選択肢にあっても使われない可能性が高いので消しました

