### PR TITLE
Optimizer Selector の PR コメント対応

### DIFF
--- a/blueoil/blueoil_init.py
+++ b/blueoil/blueoil_init.py
@@ -296,9 +296,9 @@ def ask_questions():
         'type': 'rawlist',
         'name': 'value',
         'message': 'select optimizer:',
-        'choices': ['MomentumOptimizer',
-                    'AdamOptimizer'],
-        'default': 'MomentumOptimizer'
+        'choices': ['Momentum',
+                    'Adam'],
+        'default': 'Momentum'
     }
     training_optimizer = prompt(training_optimizer_question)
 

--- a/blueoil/generate_lmnet_config.py
+++ b/blueoil/generate_lmnet_config.py
@@ -147,9 +147,9 @@ def _blueoil_to_lmnet(blueoil_config):
     # trainer
     batch_size = blueoil_config["trainer"]["batch_size"]
     optimizer  = blueoil_config["trainer"]["optimizer"]
-    if optimizer == 'AdamOptimizer':
+    if optimizer == 'Adam':
         optimizer_class = "tf.train.AdamOptimizer"
-    elif optimizer == 'MomentumOptimizer':
+    elif optimizer == 'Momentum':
         optimizer_class = "tf.train.MomentumOptimizer"
     else:
         raise ValueError("not supported optimizer.")
@@ -162,7 +162,7 @@ def _blueoil_to_lmnet(blueoil_config):
 
     learning_rate_func = None
     learning_rate_kwargs = None
-    if optimizer == "MomentumOptimizer":
+    if optimizer == "Momentum":
         optimizer_kwargs = {"momentum": 0.9, "learning_rate": initial_learning_rate}
     else:
         optimizer_kwargs = {"learning_rate": initial_learning_rate}

--- a/blueoil/templates/blueoil-config.tpl.yml
+++ b/blueoil/templates/blueoil-config.tpl.yml
@@ -11,7 +11,7 @@ dataset:
 trainer:
   batch_size: {{ batch_size }}
   epochs: {{ training_epochs }}
-  # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
+  # supported 'optimizer' is 'Momentum', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
   # Adam

--- a/blueoil_test.sh
+++ b/blueoil_test.sh
@@ -16,7 +16,7 @@ TEST_LOG_NO=0
 FAILED_TEST_NO=""
 
 # list of avairable optimizers listed in blueoil_init.py
-OPTIMIZSERS=("MomentumOptimizer" "AdamOptimizer")
+OPTIMIZSERS=("Momentum" "Adam")
 
 function usage_exit(){
 	echo ""

--- a/docs/usage/init.md
+++ b/docs/usage/init.md
@@ -70,4 +70,4 @@ trainer:
   optimizer: Adam
 ```
 
-Blueoil use this optimizers with your input learning rate. Other values are TensorFlow default described in TensorFlow documentation.
+Blueoil use this optimizers with your input learning rate for both Adam and Momentum, `momentum=0.9` for Momentum. Other values are TensorFlow default described in TensorFlow documentation.

--- a/docs/usage/init.md
+++ b/docs/usage/init.md
@@ -34,7 +34,7 @@ You don't need to re-run `bluoil init` again.
 #### data augmentation
 You can use various augmentation methods in generated YAML, also you can change augmentation methods's parameter.
 Under `commmon.data_augmentation` in generated yaml, augmentation methods are listed and the parameters are nested in each methods.
-
+```
 
 generated yaml:
 ```

--- a/docs/usage/init.md
+++ b/docs/usage/init.md
@@ -60,12 +60,14 @@ You can choose optimizer from Adam or Momentum. Each optimizer uses TensorFlow i
 generated yaml:
 
 ```
-  # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
+trainer:
+  ...
+  # supported 'optimizer' is 'Momentum', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
-  optimizer: AdamOptimizer
+  optimizer: Adam
 ```
 
 Blueoil use this optimizers with your input learning rate. Other values are TensorFlow default described in TensorFlow documentation.

--- a/docs/usage/init.md
+++ b/docs/usage/init.md
@@ -70,4 +70,4 @@ trainer:
   optimizer: Adam
 ```
 
-Blueoil use this optimizers with your input learning rate for both Adam and Momentum, `momentum=0.9` for Momentum. Other values are TensorFlow default described in TensorFlow documentation.
+Blueoil use optimizers with your input learning rate for both Adam and Momentum, and `momentum=0.9` for Momentum. Other values are TensorFlow default described in TensorFlow documentation.

--- a/tests/config/caltech101_classification.yml
+++ b/tests/config/caltech101_classification.yml
@@ -11,12 +11,12 @@ dataset:
 trainer:
   batch_size: 1
   epochs: 1
-  # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
+  # supported 'optimizer' is 'Momentum', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
-  optimizer: AdamOptimizer
+  optimizer: Adam
   # supported 'learning_rate_schedule' is 'constant', '2-step-decay', '3-step-decay', '3-step-decay-with-warmup' ({epochs} is the number of training epochs you entered before).
   #   'constant' -> constant learning rate.
   #   '2-step-decay' -> learning rate decrease by 1/10 on {epochs}/2 and {epochs}-1.

--- a/tests/config/caltech101_classification_has_validation.yml
+++ b/tests/config/caltech101_classification_has_validation.yml
@@ -11,12 +11,12 @@ dataset:
 trainer:
   batch_size: 1
   epochs: 1
-  # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
+  # supported 'optimizer' is 'Momentum', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
-  optimizer: AdamOptimizer
+  optimizer: Adam
   # supported 'learning_rate_schedule' is 'constant', '2-step-decay', '3-step-decay', '3-step-decay-with-warmup' ({epochs} is the number of training epochs you entered before).
   #   'constant' -> constant learning rate.
   #   '2-step-decay' -> learning rate decrease by 1/10 on {epochs}/2 and {epochs}-1.

--- a/tests/config/delta_mark_classification.yml
+++ b/tests/config/delta_mark_classification.yml
@@ -11,12 +11,12 @@ dataset:
 trainer:
   batch_size: 1
   epochs: 1
-  # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
+  # supported 'optimizer' is 'Momentum', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
-  optimizer: AdamOptimizer
+  optimizer: Adam
   # supported 'learning_rate_schedule' is 'constant', '2-step-decay', '3-step-decay', '3-step-decay-with-warmup' ({epochs} is the number of training epochs you entered before).
   #   'constant' -> constant learning rate.
   #   '2-step-decay' -> learning rate decrease by 1/10 on {epochs}/2 and {epochs}-1.

--- a/tests/config/delta_mark_classification_has_validation.yml
+++ b/tests/config/delta_mark_classification_has_validation.yml
@@ -11,12 +11,12 @@ dataset:
 trainer:
   batch_size: 1
   epochs: 1
-  # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
+  # supported 'optimizer' is 'Momentum', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
-  optimizer: AdamOptimizer
+  optimizer: Adam
   # supported 'learning_rate_schedule' is 'constant', '2-step-decay', '3-step-decay', '3-step-decay-with-warmup' ({epochs} is the number of training epochs you entered before).
   #   'constant' -> constant learning rate.
   #   '2-step-decay' -> learning rate decrease by 1/10 on {epochs}/2 and {epochs}-1.

--- a/tests/config/delta_mark_object_detection.yml
+++ b/tests/config/delta_mark_object_detection.yml
@@ -11,12 +11,12 @@ dataset:
 trainer:
   batch_size: 1
   epochs: 1
-  # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
+  # supported 'optimizer' is 'Momentum', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
-  optimizer: MomentumOptimizer
+  optimizer: Momentum
   # supported 'learning_rate_schedule' is 'constant', '2-step-decay', '3-step-decay', '3-step-decay-with-warmup' ({epochs} is the number of training epochs you entered before).
   #   'constant' -> constant learning rate.
   #   '2-step-decay' -> learning rate decrease by 1/10 on {epochs}/2 and {epochs}-1.

--- a/tests/config/delta_mark_object_detection_has_validation.yml
+++ b/tests/config/delta_mark_object_detection_has_validation.yml
@@ -11,12 +11,12 @@ dataset:
 trainer:
   batch_size: 1
   epochs: 1
-  # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
+  # supported 'optimizer' is 'Momentum', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
-  optimizer: MomentumOptimizer
+  optimizer: Momentum
   # supported 'learning_rate_schedule' is 'constant', '2-step-decay', '3-step-decay', '3-step-decay-with-warmup' ({epochs} is the number of training epochs you entered before).
   #   'constant' -> constant learning rate.
   #   '2-step-decay' -> learning rate decrease by 1/10 on {epochs}/2 and {epochs}-1.

--- a/tests/config/make_yml_config.py
+++ b/tests/config/make_yml_config.py
@@ -101,7 +101,7 @@ trainer_epochs = [
 ]
 
 trainer_optimizer_comment = """\
-  # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
+  # supported 'optimizer' is 'Momentum', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
   # Adam
@@ -109,14 +109,14 @@ trainer_optimizer_comment = """\
 """
 
 trainer_optimizers = [
-    '  optimizer: AdamOptimizer\n',
-    '  optimizer: AdamOptimizer\n',
-    '  optimizer: AdamOptimizer\n',
-    '  optimizer: AdamOptimizer\n',
-    '  optimizer: MomentumOptimizer\n',
-    '  optimizer: MomentumOptimizer\n',
-    '  optimizer: MomentumOptimizer\n',
-    '  optimizer: MomentumOptimizer\n',
+    '  optimizer: Adam\n',
+    '  optimizer: Adam\n',
+    '  optimizer: Adam\n',
+    '  optimizer: Adam\n',
+    '  optimizer: Momentum\n',
+    '  optimizer: Momentum\n',
+    '  optimizer: Momentum\n',
+    '  optimizer: Momentum\n',
 ]
 
 trainer_lr_schedule_comment = """\

--- a/tests/config/openimagesv4_object_detection.yml
+++ b/tests/config/openimagesv4_object_detection.yml
@@ -11,12 +11,12 @@ dataset:
 trainer:
   batch_size: 1
   epochs: 1
-  # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
+  # supported 'optimizer' is 'Momentum', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
-  optimizer: MomentumOptimizer
+  optimizer: Momentum
   # supported 'learning_rate_schedule' is 'constant', '2-step-decay', '3-step-decay', '3-step-decay-with-warmup' ({epochs} is the number of training epochs you entered before).
   #   'constant' -> constant learning rate.
   #   '2-step-decay' -> learning rate decrease by 1/10 on {epochs}/2 and {epochs}-1.

--- a/tests/config/openimagesv4_object_detection_has_validation.yml
+++ b/tests/config/openimagesv4_object_detection_has_validation.yml
@@ -11,12 +11,12 @@ dataset:
 trainer:
   batch_size: 1
   epochs: 1
-  # supported 'optimizer' is 'Momentum', 'SGD', 'Adam' currently.
+  # supported 'optimizer' is 'Momentum', 'Adam' currently.
   # Momentum
   #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
   # Adam
   #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
-  optimizer: MomentumOptimizer
+  optimizer: Momentum
   # supported 'learning_rate_schedule' is 'constant', '2-step-decay', '3-step-decay', '3-step-decay-with-warmup' ({epochs} is the number of training epochs you entered before).
   #   'constant' -> constant learning rate.
   #   '2-step-decay' -> learning rate decrease by 1/10 on {epochs}/2 and {epochs}-1.


### PR DESCRIPTION
Optimizer Seelctor の PR の @ruimashita さんのコメントへの対応を行いました
https://github.com/blue-oil/blueoil/pull/28#pullrequestreview-198450143

## 修正内容

- ドキュメントが壊れていたものを修正
- Optimizer を選択するときに `AdamOptimizer` ではなく `Adam` のような選択肢にする

## テスト方法

- `blueoil_test.sh` でテストを流しました
- `blueoil.sh init` で `Adam`, `Momentum` 両方の config を作成したあと `blueoil.sh train` で学習が開始できることを確認しました
- ドキュメントが正常に表示されることを確認しました
  - https://deploy-preview-140--blueoil.netlify.com/usage/init.html#optimizer